### PR TITLE
Fix return of filtered subnets

### DIFF
--- a/milldeploy.py
+++ b/milldeploy.py
@@ -250,7 +250,7 @@ def get_subnets(ec2_client):
         if subnet["VpcId"] == vpcId:
             vpc_subnets.append(subnet)
 
-    return subnets
+    return vpc_subnets
 
 def get_subnet_availability_zones(ec2_client):
     av_zones = []


### PR DESCRIPTION
hi @dbernstein 
It was needed to fix that as the script has tried to use also the subnets in the default vpn.

I have also replaced the ami-c29e1cb8 with an ami that we own.
Please note that the ami are specific of a region/account so in Dublin I don't have access to the ami-291cb8 available in Virginia.
You should consider to document that, make the ami ID a variable or share an official "approved" AMI for duracloud mill